### PR TITLE
Bump project version to `3.0.0-SNAPSHOT`

### DIFF
--- a/.github/workflows/pr-basic-test.yml
+++ b/.github/workflows/pr-basic-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 17
 
     - name: License check
       run: mvn license:check

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 17
 
     - name: clean disk
       if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/io-amqp1_0-impl/pom.xml
+++ b/io-amqp1_0-impl/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pulsar-io-amqp1_0-parent</artifactId>
     <groupId>org.apache.pulsar.ecosystem</groupId>
-    <version>2.12.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/io-amqp1_0-impl/pom.xml
+++ b/io-amqp1_0-impl/pom.xml
@@ -25,15 +25,15 @@
   <parent>
     <artifactId>pulsar-io-amqp1_0-parent</artifactId>
     <groupId>org.apache.pulsar.ecosystem</groupId>
-    <version>2.8.0-rc-202105251229</version>
+    <version>2.12.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pulsar-io-amqp1_0</artifactId>
 
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.pulsar.ecosystem</groupId>
   <artifactId>pulsar-io-amqp1_0-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.12.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Pulsar Ecosystem :: IO Connector :: AMQP1_0</name>
   <description>This is an Apache Pulsar AMQP1_0 connector</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
 
     <!-- build plugin dependencies -->
     <license.plugin.version>3.0</license.plugin.version>
-    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <nifi.nar.plugin.version>1.2.0</nifi.nar.plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,12 @@
 
     <!-- build plugin dependencies -->
     <license.plugin.version>3.0</license.plugin.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <nifi.nar.plugin.version>1.2.0</nifi.nar.plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
-    <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,14 @@
   <groupId>org.apache.pulsar.ecosystem</groupId>
   <artifactId>pulsar-io-amqp1_0-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.8.0-rc-202105251229</version>
+  <version>2.12.0-SNAPSHOT</version>
   <name>Pulsar Ecosystem :: IO Connector :: AMQP1_0</name>
   <description>This is an Apache Pulsar AMQP1_0 connector</description>
 
   <properties>
-    <java.version>1.8</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>false</redirectTestOutputToFile>
@@ -47,8 +49,8 @@
 
     <!-- connector dependencies -->
     <jackson.version>2.12.6.1</jackson.version>
-    <lombok.version>1.16.22</lombok.version>
-    <pulsar.version>2.8.0-rc-202105251229</pulsar.version>
+    <lombok.version>1.18.22</lombok.version>
+    <pulsar.version>2.11.0.0-rc3</pulsar.version>
     <qpid.version>0.56.0</qpid.version>
     <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pulsar-io-amqp1_0-parent</artifactId>
     <groupId>org.apache.pulsar.ecosystem</groupId>
-    <version>2.12.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pulsar-io-amqp1_0-parent</artifactId>
     <groupId>org.apache.pulsar.ecosystem</groupId>
-    <version>2.8.0-rc-202105251229</version>
+    <version>2.12.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
### Motivation

Bump Project version to `3.0.0-SNAPSHOT`.
Use JDK 17 instead of JDK 8.

### Modifications

Bump Project version to `3.0.0-SNAPSHOT`.
Bump Pulsar version to `2.11.0.0-rc3`.
Change JDK to 17.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

