### PR TITLE
Bump qpid from 0.56.0 to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jackson.version>2.12.6.1</jackson.version>
     <lombok.version>1.18.22</lombok.version>
     <pulsar.version>2.11.0.0-rc3</pulsar.version>
-    <qpid.version>0.56.0</qpid.version>
+    <qpid.version>1.8.0</qpid.version>
     <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>
 


### PR DESCRIPTION
### Motivation

There were connection losts with Redhat AMQ Broker, rendering the source inactive i.e. not picking up new messages. One of the things I noticed was that the Qpid version was from December 2020. https://qpid.apache.org/releases/index.html.
After updating Qpid our stale connection problem dissapeared.

### Modifications

Bumped the qpid version to the version 1.8.0.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  qpid version is in the master pom and not in the documentation
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

