### PR TITLE
qpid-bump,possibility to connect with failover and url-options

### DIFF
--- a/docs/amqp-1-0-sink.md
+++ b/docs/amqp-1-0-sink.md
@@ -64,10 +64,18 @@ You can create a configuration file (JSON or YAML) to set the following properti
 
 A Connection object can be specified as follows:
 
-| Name | Type|Required | Default | Description 
-|------|----------|----------|---------|-------------|
-| `useFailover` |boolean| true | false | If it is set to true, the connection will be created from the uris provided under uris, using qpid's failover connection factory. |
-| `uris` | list of ConnectionUri| true | " " (empty string) | A list of ConnectionUri objects. When useFailover is set to true 1 or more should be provided. Currently only 1 uri is supported when useFailover is set to false|
+| Name       | Type                  | Required | Default | Description                                                                                                                                                       
+|------------|-----------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `failover` | Failover              | false    | " " (empty string) | The configuration for a failover connection.                                                                                                                      |
+| `uris`     | list of ConnectionUri | true     | " " (empty string) | A list of ConnectionUri objects. When useFailover is set to true 1 or more should be provided. Currently only 1 uri is supported when useFailover is set to false |
+
+A Failover object can be specified as follows:
+
+| Name                           | Type    | Required                                         | Default | Description                                                                                                                                                                                                                                                     
+|--------------------------------|---------|--------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `useFailover`                  | boolean | true                                             | false | If it is set to true, the connection will be created from the uris provided under uris, using qpid's failover connection factory.                                                                                                                               |
+| `jmsClientId`                  | String  | required if failoverConfigurationOptions is used | " " (empty string) | Identifying name for the jms Client                                                                                                                                                                                                                             |
+| `failoverConfigurationOptions` | List of String | required if jmsClientId is used | " " (empty string) | A list of options (e.g. <key=value>). The options wil be joined using an '&', prefixed with a the jmsClientId and added to the end of the failoverUri. see also: https://qpid.apache.org/releases/qpid-jms-2.2.0/docs/index.html#failover-configuration-options |
 
 A ConnectionUri object can be specified as follows:
 | Name | Type|Required | Default | Description 
@@ -106,7 +114,8 @@ You can create a configuration file (JSON or YAML) to set the properties as belo
             "queue": "user-op-queue-pulsar"
         }
     }
-    
+    ```
+
 Or:
     
     ```json
@@ -117,10 +126,11 @@ Or:
         "inputs": ["user-op-queue-topic"],
         "archive": "connectors/pulsar-io-amqp1_0-{{connector:version}}.nar",
         "parallelism": 1,
-        "configs":
-        {
+        "configs": {
             "connection": {
-                "useFailover": true,
+                "failover": {
+                    "useFailover": true
+                },
                 "uris": [{
                         "protocol": "amqp",
                         "host": "localhost",
@@ -134,7 +144,8 @@ Or:
             "queue": "user-op-queue-pulsar"
         }
     }
-
+    ```
+    
 * YAML
 
 [deprecated]
@@ -161,28 +172,26 @@ Or:
 Or:
     
     ```yaml
-    tenant: "public"
-    namespace: "default"
-    name: "amqp1_0-sink"
-    inputs: 
-      - "user-op-queue-topic"
-    archive: "connectors/pulsar-io-amqp1_0-{{connector:version}}.nar"
+    tenant: public
+    namespace: default
+    name: amqp1_0-sink
+    inputs:
+      - user-op-queue-topic
+    archive: connectors/pulsar-io-amqp1_0-{{connector:version}}.nar
     parallelism: 1
-    
     configs:
-        connection: {
-            useFailover: true,
-            uris: [{
-                    protocol: "amqp",
-                    host: "localhost",
-                    port: 5672,
-                    urlOptions: ["transport.tcpKeepAlive=true"]
-                }
-            ]
-        }
-        username: "guest"
-        password: "guest"
-        queue: "user-op-queue-pulsar"
+      connection:
+        failover:
+          useFailover: true
+        uris:
+          - protocol: amqp
+            host: localhost
+            port: 5672
+            urlOptions:
+              - transport.tcpKeepAlive=true
+      username: guest
+      password: guest
+      queue: user-op-queue-pulsar
     ```
 
 ## Configure it with Function Mesh
@@ -248,16 +257,15 @@ spec:
     customSchemaSources:
       “persistent://public/default/user-op-queue-topic”: “org.apache.pulsar.client.impl.schema.ByteBufferSchema”
   sinkConfig:
-    connection: {
-        useFailover: true,
-        uris: [{
-                protocol: "amqp",
-                host: "localhost",
-                port: 5672,
-                urlOptions: ["transport.tcpKeepAlive=true"]
-            }
-        ]
-    }
+    connection:
+      failover:
+        useFailover: true
+      uris:
+        - protocol: amqp
+          host: localhost
+          port: 5672
+          urlOptions:
+            - transport.tcpKeepAlive=true
     username: "guest"
     password: "guest"
     queue: "user-op-queue-pulsar"
@@ -585,16 +593,15 @@ This example demonstrates how to create an AMQP1_0 sink connector through Functi
         customSchemaSources:
         “persistent://public/default/user-op-queue-topic”: “org.apache.pulsar.client.impl.schema.ByteBufferSchema”
     sinkConfig:
-        connection: {
-            useFailover: true,
-            uris: [{
-                    protocol: "amqp",
-                    host: "localhost",
-                    port: 5672,
-                    urlOptions: ["transport.tcpKeepAlive=true"]
-                }
-            ]
-        }
+        connection:
+          failover:
+            useFailover: true
+          uris:
+            - protocol: amqp
+              host: localhost
+              port: 5672
+              urlOptions:
+                - transport.tcpKeepAlive=true
         username: "guest"
         password: "guest"
         queue: "user-op-queue-pulsar"

--- a/docs/amqp-1-0-source.md
+++ b/docs/amqp-1-0-source.md
@@ -63,10 +63,18 @@ You can create a configuration file (JSON or YAML) to set the following properti
 
 A Connection object can be specified as follows:
 
-| Name | Type|Required | Default | Description 
-|------|----------|----------|---------|-------------|
-| `useFailover` |boolean| true | false | If it is set to true, the connection will be created from the uris provided under uris, using qpid's failover connection factory. |
-| `uris` | list of ConnectionUri| true | " " (empty string) | A list of ConnectionUri objects. When useFailover is set to true 1 or more should be provided. Currently only 1 uri is supported when useFailover is set to false|
+| Name       | Type                  | Required | Default | Description                                                                                                                                                       
+|------------|-----------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `failover` | Failover              | false    | " " (empty string) | The configuration for a failover connection.                                                                                                                      |
+| `uris`     | list of ConnectionUri | true     | " " (empty string) | A list of ConnectionUri objects. When useFailover is set to true 1 or more should be provided. Currently only 1 uri is supported when useFailover is set to false |
+
+A Failover object can be specified as follows:
+
+| Name                           | Type    | Required                                         | Default | Description                                                                                                                                                                                                                                                     
+|--------------------------------|---------|--------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `useFailover`                  | boolean | true                                             | false | If it is set to true, the connection will be created from the uris provided under uris, using qpid's failover connection factory.                                                                                                                               |
+| `jmsClientId`                  | String  | required if failoverConfigurationOptions is used | " " (empty string) | Identifying name for the jms Client                                                                                                                                                                                                                             |
+| `failoverConfigurationOptions` | List of String | required if jmsClientId is used | " " (empty string) | A list of options (e.g. <key=value>). The options wil be joined using an '&', prefixed with a the jmsClientId and added to the end of the failoverUri. see also: https://qpid.apache.org/releases/qpid-jms-2.2.0/docs/index.html#failover-configuration-options |
 
 A ConnectionUri object can be specified as follows:
 | Name | Type|Required | Default | Description 
@@ -119,7 +127,9 @@ or:
         "parallelism": 1,
         "configs": {
             "connection": {
-                "useFailover": true,
+                "failover": {
+                    "useFailover": true
+                },
                 "uris": [{
                         "protocol": "amqp",
                         "host": "localhost",
@@ -162,27 +172,25 @@ or
 * YAML
 
     ```yaml
-        tenant: "public"
-        namespace: "default"
-        name: "amqp1_0-source"
-        topicName: "user-op-queue-topic"
-        archive: "connectors/pulsar-io-amqp1_0-{{connector:version}}.nar"
-        parallelism: 1
-        
-        configs:
-            connection: {
-                useFailover: true,
-                uris: [{
-                        protocol: "amqp",
-                        host: "localhost",
-                        port: 5672,
-                        urlOptions: ["transport.tcpKeepAlive=true"]
-                    }
-                ]
-            }
-            username: "guest"
-            password: "guest"
-            queue: "user-op-queue"
+    tenant: public
+    namespace: default
+    name: amqp1_0-source
+    topicName: user-op-queue-topic
+    archive: connectors/pulsar-io-amqp1_0-{{connector:version}}.nar
+    parallelism: 1
+    configs:
+        connection:
+            failover:
+                useFailover: true
+            uris:
+                - protocol: amqp
+                  host: localhost
+                  port: 5672
+                  urlOptions:
+                    - transport.tcpKeepAlive=true
+        username: guest
+        password: guest
+        queue: user-op-queue
     ```
     
 ## Configure it with Function Mesh
@@ -241,16 +249,15 @@ spec:
     topic: persistent://public/default/user-op-queue-topic
     typeClassName: “java.nio.ByteBuffer”
   sourceConfig:
-    connection: {
-        useFailover: true,
-        uris: [{
-                protocol: "amqp",
-                host: "localhost",
-                port: 5672,
-                urlOptions: ["transport.tcpKeepAlive=true"]
-            }
-        ]
-    }
+    connection:
+        failover:
+            useFailover: true
+        uris:
+            - protocol: amqp
+              host: localhost
+              port: 5672
+              urlOptions:
+                - transport.tcpKeepAlive=true
     username: "guest"
     password: "guest"
     queue: "user-op-queue"
@@ -266,7 +273,7 @@ spec:
   java:
     jar: connectors/pulsar-io-amqp1_0-{{connector:version}}.nar
   clusterName: test-pulsar
-
+```
 
 
 # How to use
@@ -568,16 +575,16 @@ Or:
         topic: persistent://public/default/user-op-queue-topic
         typeClassName: “java.nio.ByteBuffer”
     sourceConfig:
-        connection: {
-            useFailover: true,
-            uris: [{
-                    protocol: "amqp",
-                    host: "localhost",
-                    port: 5672,
-                    urlOptions: ["transport.tcpKeepAlive=true"]
-                }
-            ]
-        }
+        
+        connection:
+            failover:
+                useFailover: true
+            uris:
+                - protocol: amqp
+                  host: localhost
+                  port: 5672
+                  urlOptions:
+                    - transport.tcpKeepAlive=true
         username: "guest"
         password: "guest"
         queue: "user-op-queue"

--- a/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/AmqpBaseConfig.java
+++ b/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/AmqpBaseConfig.java
@@ -39,10 +39,19 @@ public class AmqpBaseConfig {
     private String username;
     private String password;
     @Deprecated
+    /* Use Connection with failover support instead
+     For single uri configuration without failover support provide a list with one ConnectionUri in Connection
+    */
     private String host;
     @Deprecated
+    /* Use Connection with failover support instead
+     For single uri configuration without failover support provide a list with one ConnectionUri in Connection
+    */
     private String protocol;
     @Deprecated
+    /* Use Connection with failover support instead
+      For single uri configuration without failover support provide a list with one ConnectionUri in Connection
+     */
     private int port;
     private String queue;
     private String topic;
@@ -57,7 +66,7 @@ public class AmqpBaseConfig {
     public void validate() throws ConfigurationInvalidException {
 
         if (connection != null) {
-            if (isValidUrlComponentConfiguration()){
+            if (isValidProtocolConfiguration() || isValidHostConfiguration() || isValidPortConfiguration()){
                 throw new ConfigurationInvalidException(
                         "When connection is set, protocol, host, port should be empty.");
             }
@@ -101,11 +110,24 @@ public class AmqpBaseConfig {
         return destination;
     }
 
-
     private boolean isValidUrlComponentConfiguration() {
-        return StringUtils.isNotEmpty(protocol)
-                && StringUtils.isNotEmpty(host)
-                && port > 0;
+        return isValidProtocolConfiguration()
+                && isValidHostConfiguration()
+                && isValidPortConfiguration();
     }
+
+    private boolean isValidProtocolConfiguration() {
+        return StringUtils.isNotEmpty(protocol);
+    }
+
+    private boolean isValidHostConfiguration() {
+        return StringUtils.isNotEmpty(host);
+    }
+
+    private boolean isValidPortConfiguration() {
+        return port > 0;
+    }
+
+
 
 }

--- a/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/Connection.java
+++ b/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/Connection.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.ecosystem.io.amqp;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * Connection with a list of URI's and whether the failover prefix should be used.
+ */
+@Data
+@Accessors(chain = true)
+public class Connection {
+
+    private boolean useFailover;
+    private List<ConnectionUri> uris;
+
+    public String getUri(){
+        String urisString = this.uris
+                .stream()
+                .map(ConnectionUri::getUri)
+                .collect(Collectors.joining(","));
+        return useFailover ? "failover:(" + urisString + ")" : urisString;
+    }
+
+    public void validate() throws ConfigurationInvalidException {
+
+        if (null == uris || uris.isEmpty()){
+            throw new ConfigurationInvalidException("No uri's specified in connection");
+        }
+
+        if (uris.size() > 1 && !useFailover) {
+            throw new ConfigurationInvalidException("Multiple uri's currently only supported when useFailover is "
+                    + "set to true");
+        }
+
+        for (ConnectionUri host : uris) {
+            if (host == null){
+                throw new ConfigurationInvalidException("Host cannot be null in connection");
+            }
+            host.validate();
+        }
+    }
+}

--- a/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionUri.java
+++ b/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionUri.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pulsar.ecosystem.io.amqp;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -34,6 +37,11 @@ public class ConnectionUri {
     private int port;
     private List<String> urlOptions;
 
+    public static ConnectionUri load(Map<String, Object> config) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(objectMapper.writeValueAsBytes(config), ConnectionUri.class);
+    }
+
     public void validate() throws ConfigurationInvalidException {
         if (StringUtils.isEmpty(this.protocol)
                 || StringUtils.isEmpty(this.host)
@@ -48,10 +56,9 @@ public class ConnectionUri {
     }
 
     private String getUrlOptionsAsString() {
-        String urlOptionsAsString = "";
         if (urlOptions != null && !urlOptions.isEmpty()){
             return "?" + String.join("&", urlOptions);
         }
-        return urlOptionsAsString;
+        return "";
     }
 }

--- a/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionUri.java
+++ b/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionUri.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.ecosystem.io.amqp;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * Uri of connection.
+ */
+@Data
+@Accessors(chain = true)
+public class ConnectionUri {
+    private String protocol;
+    private String host;
+    private int port;
+    private List<String> urlOptions;
+
+    public void validate() throws ConfigurationInvalidException {
+        if (StringUtils.isEmpty(this.protocol)
+                || StringUtils.isEmpty(this.host)
+                || port <= 0){
+            throw new ConfigurationInvalidException("Protocol, host and port should be set for all uris in "
+                    + "connection");
+        }
+    }
+
+    public String getUri() {
+        return this.protocol + "://" + host + ":" + port + getUrlOptionsAsString();
+    }
+
+    private String getUrlOptionsAsString() {
+        String urlOptionsAsString = "";
+        if (urlOptions != null && !urlOptions.isEmpty()){
+            return "?" + String.join("&", urlOptions);
+        }
+        return urlOptionsAsString;
+    }
+}

--- a/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/Failover.java
+++ b/io-amqp1_0-impl/src/main/java/org/apache/pulsar/ecosystem/io/amqp/Failover.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.ecosystem.io.amqp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * Failover configuration.
+ */
+@Data
+@Accessors(chain = true)
+public class Failover {
+    private boolean useFailover;
+    private String jmsClientId;
+    private List<String> failoverConfigurationOptions;
+
+    public static Failover load(Map<String, Object> config) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(objectMapper.writeValueAsBytes(config), Failover.class);
+    }
+    public void validate() throws ConfigurationInvalidException {
+        if (!useFailover) {
+            if (failoverConfigurationOptions != null && !failoverConfigurationOptions.isEmpty()) {
+                throw new ConfigurationInvalidException("failoverConfigurationOptions is only supported when failover "
+                        + "is configured with useFailover set to true and jmsClientId provided");
+
+            }
+            if (StringUtils.isNotEmpty(jmsClientId)) {
+                throw new ConfigurationInvalidException("jmsClientId is only supported when failover is configured "
+                        + "with useFailover set to true and failoverConfigurationOptions provided");
+            }
+        } else {
+
+            if (StringUtils.isEmpty(jmsClientId) && failoverConfigurationOptions != null
+                    && !failoverConfigurationOptions.isEmpty()) {
+                throw new ConfigurationInvalidException("failoverConfigurationOptions is only supported when failover "
+                        + "is configured with useFailover set to true and jmsClientId provided");
+            }
+
+            if (StringUtils.isNotEmpty(jmsClientId)
+                    && (failoverConfigurationOptions == null || failoverConfigurationOptions.isEmpty())) {
+                throw new ConfigurationInvalidException("jmsClientId is only supported when failover is configured "
+                        + "with useFailover set to true and failoverConfigurationOptions provided");
+            }
+        }
+
+    }
+    public String getFailoverPrefix(){
+        if (useFailover){
+            return "failover:(";
+        }
+        return "";
+    }
+    public String getFailoverSuffix(){
+        if (useFailover){
+            return  ")" + getFailoverConfigurationOptionsAsString();
+        }
+        return "";
+    }
+
+    private String getFailoverConfigurationOptionsAsString() {
+        if (failoverConfigurationOptions != null && !failoverConfigurationOptions.isEmpty()) {
+            return "?" + getJmsClientIdUrlOptionAsString()
+                    + "&" + String.join("&", failoverConfigurationOptions);
+        }
+        return "";
+    }
+
+    private String getJmsClientIdUrlOptionAsString() {
+        return "jms.clientID=" + jmsClientId;
+    }
+}

--- a/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/AmqpBaseConfigTest.java
+++ b/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/AmqpBaseConfigTest.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pulsar.ecosystem.io.amqp;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,6 +32,7 @@ import org.junit.Test;
  * Amqp source config test.
  */
 public class AmqpBaseConfigTest {
+
 
     @Test
     public void validateTest() throws Exception {
@@ -40,6 +45,206 @@ public class AmqpBaseConfigTest {
         Assert.assertEquals(baseConfig.getHost(), "localhost");
         Assert.assertEquals(baseConfig.getPort(), 5672);
         Assert.assertEquals(baseConfig.getQueue(), "test-queue");
+        Assert.assertEquals(baseConfig.getUri(), "amqp://localhost:5672");
+    }
+
+    @Test
+    public void validateTestConnection() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpBaseConfig.load(paramsMap);
+        baseConfig.validate();
+
+        Assert.assertEquals("amqp", baseConfig.getConnection().getUris().get(0).getProtocol());
+        Assert.assertEquals("localhost", baseConfig.getConnection().getUris().get(0).getHost());
+        Assert.assertEquals(5672, baseConfig.getConnection().getUris().get(0).getPort());
+        Assert.assertEquals("test-queue", baseConfig.getQueue());
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true", baseConfig.getUri());
+    }
+
+    @Test
+    public void validateTestConflictMultipleurisAndNoFailover() throws Exception {
+        Map<String, Object> uri1 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+        Map<String, Object> uri2 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(uri1);
+        uris.add(uri2);
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpBaseConfig.load(paramsMap);
+
+        try {
+            baseConfig.validate();
+            Assert.fail("The test should fail because multiple uris on connection is currently only "
+                    + "supported when useFailover is true");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Multiple uri's currently only supported when useFailover is set to true",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestEmptyuris() throws Exception {
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpBaseConfig.load(paramsMap);
+
+        try {
+            baseConfig.validate();
+            Assert.fail("The test should fail because uris is empty in connection");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("No uri's specified in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestNullHost() throws Exception {
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(null);
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpBaseConfig.load(paramsMap);
+
+        try {
+            baseConfig.validate();
+            Assert.fail("The test should fail because no connection contains uris with null value");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Host cannot be null in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestIncompleteHost() throws Exception {
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig(null, 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpBaseConfig.load(paramsMap);
+
+        try {
+            baseConfig.validate();
+            Assert.fail("The test should fail because connection are incomplete");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for "
+                    + "all uris in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestUriBasedOnUrlComponents() throws Exception {
+        Map<String, Object> paramsMap = getBaseConfig();
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpSourceConfig.load(paramsMap);
+        baseConfig.validate();
+        Assert.assertEquals("amqp://localhost:5672", baseConfig.getUri());
+    }
+
+    @Test
+    public void validateTestUriBasedOnConnection() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpSourceConfig.load(paramsMap);
+        baseConfig.validate();
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true", baseConfig.getUri());
+    }
+
+    @Test
+    public void validateTestUriBasedOnConnectionWithMultipleUrlOptions() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true", "extra_property=false")));
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(false, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpSourceConfig.load(paramsMap);
+        baseConfig.validate();
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true&extra_property=false",
+                baseConfig.getUri());
+    }
+
+    @Test
+    public void validateTestFailoverUrl() throws Exception {
+        Map<String, Object> uri1 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+        Map<String, Object> uri2 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(uri1);
+        uris.add(uri2);
+
+        Map<String, Object> paramsMap = getBaseConfigConnection(true, uris);
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig baseConfig = AmqpSourceConfig.load(paramsMap);
+        baseConfig.validate();
+        Assert.assertEquals("failover:(amqp://localhost:5672?transport.tcpKeepAlive=true,"
+                + "amqp://localhost:5672?transport.tcpKeepAlive=true)", baseConfig.getUri());
+    }
+
+
+    @Test
+    public void uriConflictSetTest() throws Exception {
+        Map<String, Object> paramsMap = getBaseConfig();
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        paramsMap.putAll(getBaseConfigConnection(false, uris));
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig sourceConfig = AmqpSourceConfig.load(paramsMap);
+        try {
+            sourceConfig.validate();
+            Assert.fail("The test should fail because connectiondetails is set at the same time as "
+                    + "protocol, host, port and/or urlOptions");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("When connection is set, protocol, host, port should be empty.",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void invalidConfigNoRawUrlProtocolHostAndPort() throws Exception {
+        Map<String, Object> paramsMap = new HashMap<>();
+        paramsMap.put("queue", "test-queue");
+        AmqpBaseConfig sourceConfig = AmqpSourceConfig.load(paramsMap);
+        try {
+            sourceConfig.validate();
+            Assert.fail("The test should fail because no connection, protocol, host and port are set");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host, port should be set when no connection is provided.",
+                    e.getMessage());
+        }
     }
 
     @Test
@@ -91,4 +296,25 @@ public class AmqpBaseConfigTest {
         return paramsMap;
     }
 
+    private Map<String, Object> getBaseConfigConnection(boolean useFailover,
+                                                               ArrayList<Map<String, Object>> uris) {
+        Map<String, Object> paramsMap = new HashMap<>();
+        Map<String, Object> connectionMap = new HashMap<>();
+
+        connectionMap.put("useFailover", useFailover);
+        connectionMap.put("uris", uris);
+
+        paramsMap.put("connection", connectionMap);
+        return paramsMap;
+    }
+
+    private Map<String, Object> getConnectionUriConfig(String host, int port, String protocol,
+                                                       List<String> urlOptions) {
+        Map<String, Object> hostMap = new HashMap<>();
+        hostMap.put("protocol", protocol);
+        hostMap.put("host", host);
+        hostMap.put("port", port);
+        hostMap.put("urlOptions", urlOptions);
+        return hostMap;
+    }
 }

--- a/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionTest.java
+++ b/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionTest.java
@@ -1,0 +1,267 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.ecosystem.io.amqp;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ConnectionTest.
+ */
+public class ConnectionTest {
+
+    @Test
+    public void validateTestConnection() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+        Connection connectionConfig = Connection.load(paramsMap);
+        connectionConfig.validate();
+
+        Assert.assertEquals("amqp", connectionConfig.getUris().get(0).getProtocol());
+        Assert.assertEquals("localhost", connectionConfig.getUris().get(0).getHost());
+        Assert.assertEquals(5672, connectionConfig.getUris().get(0).getPort());
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true", connectionConfig.getUri());
+    }
+
+    @Test
+    public void validateTestNullConnectionUri() throws Exception {
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(null);
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+
+        Connection connectionConfig = Connection.load(paramsMap);
+
+        try {
+            connectionConfig.validate();
+            Assert.fail("The test should fail because connection contains uris with null value");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("uris in Connection should contain a valid "
+                    + "combination of protocol, host and port", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestInvalidHostInConnectionUri() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+
+        Connection connectionConfig = Connection.load(paramsMap);
+
+        try {
+            connectionConfig.validate();
+            Assert.fail("The test should fail because connection contains uris with null value");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for all uris in connection",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestInvalidProtocolInConnectionUri() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+
+        Connection connectionConfig = Connection.load(paramsMap);
+
+        try {
+            connectionConfig.validate();
+            Assert.fail("The test should fail because connection contains uris with null value");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for all uris in connection",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestInvalidPortInConnectionUri() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 0, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+
+        Connection connectionConfig = Connection.load(paramsMap);
+
+        try {
+            connectionConfig.validate();
+            Assert.fail("The test should fail because connection contains uris with null value");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for all uris in connection",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestConflictMultipleUrisAndNoFailover() throws Exception {
+        Map<String, Object> uri1 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+        Map<String, Object> uri2 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(uri1);
+        uris.add(uri2);
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+        Connection connectionConfig = Connection.load(paramsMap);
+
+        try {
+            connectionConfig.validate();
+            Assert.fail("The test should fail because multiple uris on connection is currently only "
+                    + "supported when useFailover is true");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Multiple uri's currently only supported when failover is configured "
+                            + "with useFailover set to true",
+                    e.getMessage());
+        }
+    }
+    @Test
+    public void validateTestEmptyUris() throws Exception {
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris);
+        Connection connectionConfig = Connection.load(paramsMap);
+
+        try {
+            connectionConfig.validate();
+            Assert.fail("The test should fail because uris is empty in connection");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("No uri's specified in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestUriBasedOnConnection() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true")));
+
+        Map<String, Object> failover = getFailoverConfig(false, "",
+                Collections.emptyList());
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris, failover);
+        Connection connectionConfig = Connection.load(paramsMap);
+        connectionConfig.validate();
+
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true", connectionConfig.getUri());
+    }
+
+    @Test
+    public void validateTestUriBasedOnConnectionWithMultipleUrlOptions() throws Exception {
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true", "extra_property=false")));
+        Map<String, Object> failover = getFailoverConfig(false, "",
+                Collections.emptyList());
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris, failover);
+        Connection connectionConfig = Connection.load(paramsMap);
+        connectionConfig.validate();
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true&extra_property=false",
+                connectionConfig.getUri());
+    }
+
+    @Test
+    public void validateTestFailoverUrl() throws Exception {
+        Map<String, Object> uri1 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+        Map<String, Object> uri2 =
+                getConnectionUriConfig("localhost", 5672, "amqp",
+                        Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ArrayList<Map<String, Object>> uris = new ArrayList<>();
+        uris.add(uri1);
+        uris.add(uri2);
+        Map<String, Object> failover = getFailoverConfig(true, "foo",
+                Arrays.asList("failover.maxReconnectAttempts=20"));
+
+        Map<String, Object> paramsMap = getConnectionConfig(uris, failover);
+        Connection connectionConfig = Connection.load(paramsMap);
+        connectionConfig.validate();
+        Assert.assertEquals("failover:(amqp://localhost:5672?transport.tcpKeepAlive=true,"
+                + "amqp://localhost:5672?transport.tcpKeepAlive=true)?jms.clientID=foo&failover.maxReconnectAttempts=20"
+                , connectionConfig.getUri());
+    }
+
+    private Map<String, Object> getConnectionConfig(ArrayList<Map<String, Object>> uris,
+                                                        Map<String, Object> failover) {
+        Map<String, Object> connectionMap = new HashMap<>();
+
+        connectionMap.put("uris", uris);
+        connectionMap.put("failover", failover);
+
+        return connectionMap;
+    }
+
+    private Map<String, Object> getConnectionConfig(ArrayList<Map<String, Object>> uris) {
+        Map<String, Object> connectionMap = new HashMap<>();
+
+        connectionMap.put("uris", uris);
+
+        return connectionMap;
+    }
+
+    private Map<String, Object> getConnectionUriConfig(String host, int port, String protocol,
+                                                       List<String> urlOptions) {
+        Map<String, Object> hostMap = new HashMap<>();
+        hostMap.put("protocol", protocol);
+        hostMap.put("host", host);
+        hostMap.put("port", port);
+        hostMap.put("urlOptions", urlOptions);
+        return hostMap;
+    }
+
+    private Map<String, Object> getFailoverConfig(boolean useFailover, String jmsClientId,
+                                                  List<String> failoverConfigurationOptions) {
+        Map<String, Object> failoverMap = new HashMap<>();
+        failoverMap.put("useFailover", useFailover);
+        failoverMap.put("jmsClientId", jmsClientId);
+        failoverMap.put("failoverConfigurationOptions", failoverConfigurationOptions);
+        return failoverMap;
+    }
+}

--- a/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionUriTest.java
+++ b/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/ConnectionUriTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.ecosystem.io.amqp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+
+/**
+ * ConnectionUriTest.
+ */
+public class ConnectionUriTest {
+
+    @Test
+    public void validateTestConnectionUriWithHostEmpty() throws Exception {
+        Map<String, Object> paramsMap = getConnectionUriConfig("", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ConnectionUri connectionUri = ConnectionUri.load(paramsMap);
+
+        try {
+            connectionUri.validate();
+            Assert.fail("The test should fail because connection are incomplete");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for "
+                    + "all uris in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestConnectionUriWithProtocolEmpty() throws Exception {
+        Map<String, Object> paramsMap = getConnectionUriConfig("host", 5672, "",
+                Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ConnectionUri connectionUri = ConnectionUri.load(paramsMap);
+
+        try {
+            connectionUri.validate();
+            Assert.fail("The test should fail because connection are incomplete");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for "
+                    + "all uris in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestConnectionUriWithPortLessThanOne() throws Exception {
+        Map<String, Object> paramsMap = getConnectionUriConfig("test", 0, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ConnectionUri connectionUri = ConnectionUri.load(paramsMap);
+
+        try {
+            connectionUri.validate();
+            Assert.fail("The test should fail because connection are incomplete");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("Protocol, host and port should be set for "
+                    + "all uris in connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestUriBasedOnConnection() throws Exception {
+        Map<String, Object> paramsMap = getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true"));
+
+        ConnectionUri connectionUriConfig = ConnectionUri.load(paramsMap);
+        connectionUriConfig.validate();
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true", connectionUriConfig.getUri());
+    }
+
+    @Test
+    public void validateTestUriBasedOnConnectionWithMultipleUrlOptions() throws Exception {
+        Map<String, Object> paramsMap = getConnectionUriConfig("localhost", 5672, "amqp",
+                Arrays.asList("transport.tcpKeepAlive=true", "extra_property=false"));
+
+        ConnectionUri connectionUriConfig = ConnectionUri.load(paramsMap);
+        connectionUriConfig.validate();
+        Assert.assertEquals("amqp://localhost:5672?transport.tcpKeepAlive=true&extra_property=false",
+                connectionUriConfig.getUri());
+    }
+
+    private Map<String, Object> getBaseConfigConnection(ArrayList<Map<String, Object>> uris,
+                                                        Map<String, Object> failover) {
+        Map<String, Object> paramsMap = new HashMap<>();
+        Map<String, Object> connectionMap = new HashMap<>();
+
+        connectionMap.put("uris", uris);
+        connectionMap.put("failover", failover);
+
+        paramsMap.put("connection", connectionMap);
+        return paramsMap;
+    }
+
+    private Map<String, Object> getConnectionUriConfig(String host, int port, String protocol,
+                                                       List<String> urlOptions) {
+        Map<String, Object> hostMap = new HashMap<>();
+        hostMap.put("protocol", protocol);
+        hostMap.put("host", host);
+        hostMap.put("port", port);
+        hostMap.put("urlOptions", urlOptions);
+        return hostMap;
+    }
+
+    private Map<String, Object> getFailoverConfig(boolean useFailover, String jmsClientId,
+                                                  List<String> failoverConfigurationOptions) {
+        Map<String, Object> failoverMap = new HashMap<>();
+        failoverMap.put("useFailover", useFailover);
+        failoverMap.put("jmsClientId", jmsClientId);
+        failoverMap.put("failoverConfigurationOptions", failoverConfigurationOptions);
+        return failoverMap;
+    }
+}

--- a/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/FailoverTest.java
+++ b/io-amqp1_0-impl/src/test/java/org/apache/pulsar/ecosystem/io/amqp/FailoverTest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.ecosystem.io.amqp;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+
+/**
+ * FailoverTest.
+ */
+public class FailoverTest {
+
+    @Test
+    public void validateTestConflictFailoverWithJmsClientIdAndNoUseFailover() throws Exception {
+
+        Map<String, Object> failover = getFailoverConfig(false, "foo",
+                Collections.emptyList());
+
+        Failover failoverConfig = Failover.load(failover);
+
+        try {
+            failoverConfig.validate();
+            Assert.fail("The test should fail because jmsClientId is set while useFailover in failover is false");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("jmsClientId is only supported when failover is configured with useFailover set "
+                            + "to true and failoverConfigurationOptions provided",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestConflictFailoverWithFailoverConfigurationOptionsAndNoUseFailover() throws Exception {
+        Map<String, Object> failover = getFailoverConfig(false, "",
+                Arrays.asList("failover.maxReconnectAttempts=20"));
+
+        Failover failoverConfig = Failover.load(failover);
+
+        try {
+            failoverConfig.validate();
+            Assert.fail("The test should fail because failoverConfigurationOptions is set while useFailover "
+                    + "in failover is false");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("failoverConfigurationOptions is only supported when failover is configured "
+                            + "with useFailover set to true and jmsClientId provided",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestConflictFailoverWithFailoverConfigurationOptionsAndNoJmsClientId() throws Exception {
+        Map<String, Object> failover = getFailoverConfig(true, "",
+                Arrays.asList("failover.maxReconnectAttempts=20"));
+
+        Failover failoverConfig = Failover.load(failover);
+
+        try {
+            failoverConfig.validate();
+            Assert.fail("The test should fail because failover is configured with useFailover set to true, "
+                    + "failoverConfigurationOptions are provided but no jmsClientId is provided");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("failoverConfigurationOptions is only supported when failover is configured"
+                            + " with useFailover set to true and jmsClientId provided",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestConflictFailoverWithJmsClientIdButNoFailoverConfigurationOptions() throws Exception {
+        Map<String, Object> failover = getFailoverConfig(true, "foo",
+                Collections.emptyList());
+
+        Failover failoverConfig = Failover.load(failover);
+
+        try {
+            failoverConfig.validate();
+            Assert.fail("The test should fail because failover is configured with useFailover set to true and "
+                    + "failoverConfigurationOptions but no jmsClientId is provided");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ConfigurationInvalidException);
+            Assert.assertEquals("jmsClientId is only supported when failover is configured with "
+                            + "useFailover set to true and failoverConfigurationOptions provided",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void validateTestFailoverUrlPrefix() throws Exception {
+        Map<String, Object> failover = getFailoverConfig(true, "foo",
+                Arrays.asList("failover.maxReconnectAttempts=20", "failover.useReconnectBackOff=true"));
+
+        Failover failoverConfig = Failover.load(failover);
+        failoverConfig.validate();
+        Assert.assertEquals("failover:("
+                , failoverConfig.getFailoverPrefix());
+    }
+
+    @Test
+    public void validateTestFailoverUrlSuffix() throws Exception {
+        Map<String, Object> failover = getFailoverConfig(true, "",
+                Collections.emptyList());
+
+        Failover failoverConfig = Failover.load(failover);
+        failoverConfig.validate();
+        Assert.assertEquals(")", failoverConfig.getFailoverSuffix());
+    }
+
+    @Test
+    public void validateTestFailoverUrlSuffixWithFailoverOptions() throws Exception {
+        Map<String, Object> failover = getFailoverConfig(true, "foo",
+                Arrays.asList("failover.maxReconnectAttempts=20", "failover.useReconnectBackOff=true"));
+
+        Failover failoverConfig = Failover.load(failover);
+        failoverConfig.validate();
+        Assert.assertEquals(")?jms.clientID=foo&failover.maxReconnectAttempts=20"
+                + "&failover.useReconnectBackOff=true", failoverConfig.getFailoverSuffix());
+    }
+
+    private Map<String, Object> getFailoverConfig(boolean useFailover, String jmsClientId,
+                                                  List<String> failoverConfigurationOptions) {
+        Map<String, Object> failoverMap = new HashMap<>();
+        failoverMap.put("useFailover", useFailover);
+        failoverMap.put("jmsClientId", jmsClientId);
+        failoverMap.put("failoverConfigurationOptions", failoverConfigurationOptions);
+        return failoverMap;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jackson.version>2.12.6.1</jackson.version>
     <lombok.version>1.18.22</lombok.version>
     <pulsar.version>2.11.0.0-rc3</pulsar.version>
-    <qpid.version>0.56.0</qpid.version>
+    <qpid.version>1.8.0</qpid.version>
     <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>
 

--- a/tests/src/test/resources/amqp1_0-sink-config.yaml
+++ b/tests/src/test/resources/amqp1_0-sink-config.yaml
@@ -27,7 +27,11 @@ parallelism: 1
 sourceSubscriptionPosition: "Earliest"
 configs:
     connection:
-      useFailover: true
+      failover:
+        useFailover: true
+        jmsClientId: "amqp-sink"
+        failoverConfigurationOptions:
+          - "failover.maxReconnectAttempts=-1"
       uris:
         - protocol: "amqp"
           host: "solace"

--- a/tests/src/test/resources/amqp1_0-sink-config.yaml
+++ b/tests/src/test/resources/amqp1_0-sink-config.yaml
@@ -26,9 +26,14 @@ archive: "connectors/pulsar-io-amqp1_0.nar"
 parallelism: 1
 sourceSubscriptionPosition: "Earliest"
 configs:
-    protocol: "amqp"
-    host: "solace"
-    port: "5672"
+    connection:
+      useFailover: true
+      uris:
+        - protocol: "amqp"
+          host: "solace"
+          port: 5672
+          urlOptions:
+            - "transport.tcpKeepAlive=true"
     username: "guest"
     password: "guest"
     queue: "user-op-queue-pulsar"

--- a/tests/src/test/resources/amqp1_0-source-config.yaml
+++ b/tests/src/test/resources/amqp1_0-source-config.yaml
@@ -26,7 +26,11 @@ parallelism: 1
 
 configs:
     connection:
-      useFailover: true
+      failover:
+        useFailover: true
+        jmsClientId: "amqp-source"
+        failoverConfigurationOptions:
+          - "failover.maxReconnectAttempts=-1"
       uris:
         - protocol: "amqp"
           host: "solace"

--- a/tests/src/test/resources/amqp1_0-source-config.yaml
+++ b/tests/src/test/resources/amqp1_0-source-config.yaml
@@ -25,9 +25,14 @@ archive: "connectors/pulsar-io-amqp1_0.nar"
 parallelism: 1
 
 configs:
-    protocol: "amqp"
-    host: "solace"
-    port: "5672"
+    connection:
+      useFailover: true
+      uris:
+        - protocol: "amqp"
+          host: "solace"
+          port: 5672
+          urlOptions:
+            - "transport.tcpKeepAlive=true"
     username: "guest"
     password: "guest"
     queue: "user-op-queue"


### PR DESCRIPTION
### Motivation
We use the connector as source function worker on OpenShift, to connect a queue on AMQBroker with a topic on Pulsar. Occasionally the pulsar sink pod loses connection, without crashing or sending any clear logs. 

### Modifications

To solve this issue we enable the connector to use qpids failover and keepalive option. This requires a uri that is prefixed and postfixed in a certain way. Furthermore the failover option allows for connection to more than one uri. 

To make this possible we have added a 'connection' configuration option which is backwards compatible:

using the connection configuration
- requires a list of uris (host, port, protocol and, optionally, urlOptions)
- a boolean flag to indicate whether failover is to be used.
- if connection is used, the current single host, protocol and port configuration cannot be used

It is possible to use 'connection', with useFailover set to false, a list with a single host, protocol, port and no url-options. This could replace the current single host, protocol and port configuration. That is why we have deprecated the current single host, protocol and port configuration

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

example:
  - *Added unit tests to AmqpBaseConfigTest to ensure backwards compatibility and proper use of connection.
  - *no integration tests were added, but the sink- and source-conf for the integration tests now work with 'connection' configuration

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc` 
  
please find documentation under : docs/amqp-1-0-sink and docs/amqp-1-0-source


