### PR TITLE
Fix integration test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <junit.version>4.13.1</junit.version>
     <mockito.version>2.22.0</mockito.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
-    <testcontainers.version>1.15.2</testcontainers.version>
+    <testcontainers.version>1.19.0</testcontainers.version>
     <awaitility.version>4.2.0</awaitility.version>
 
     <!-- build plugin dependencies -->

--- a/tests/src/test/java/org/apache/pulsar/ecosystem/io/amqp/tests/IntegrationTest.java
+++ b/tests/src/test/java/org/apache/pulsar/ecosystem/io/amqp/tests/IntegrationTest.java
@@ -46,8 +46,6 @@ import org.junit.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 
 
 /**
@@ -109,15 +107,9 @@ public class IntegrationTest {
         waitForConnectorRunning(standaloneContainer, true, "amqp1_0-source");
         log.info("amqp1_0 source is running");
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        ObjectNode objectNode = objectMapper.createObjectNode();
-        objectNode.put("user-op-queue-topic", "org.apache.pulsar.client.impl.schema.ByteBufferSchema");
-
         execResult = standaloneContainer.execInContainer(
                 "/pulsar/bin/pulsar-admin",
                 "sinks", "create",
-                "--custom-schema-inputs",
-                objectNode.toString(),
                 "--sink-config-file",
                 "/pulsar/amqp1_0-sink-config.yaml"
                 );
@@ -136,6 +128,10 @@ public class IntegrationTest {
                 .atMost(30, TimeUnit.SECONDS)
                 .until(testSuccess::get);
         log.info("Finish the integration test.");
+
+        network.close();
+        standaloneContainer.close();
+        solaceContainer.close();
     }
 
     private void generateData(int count, String remoteUri) {


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/pulsar-io-amqp-1-0/actions/runs/6104944284/job/16568284156

The current integration test aways failed. 


Refer to the sink log. The root cause is the sink not running. 

Here we set custom schema: `org.apache.pulsar.client.impl.schema.ByteBufferSchema`

https://github.com/streamnative/pulsar-io-amqp-1-0/blob/e32946f36da76cb1a5d1d1c704fb0596f7a5b746/tests/src/test/java/org/apache/pulsar/ecosystem/io/amqp/tests/IntegrationTest.java#L119

But this class is not in the NAR of the connector.

```
java.lang.RuntimeException: User class must be in class path
	at org.apache.pulsar.common.util.Reflections.createInstance(Reflections.java:72) ~[org.apache.pulsar-pulsar-common-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.instance.InstanceUtils.createInstance(InstanceUtils.java:92) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.instance.InstanceUtils.initializeSerDe(InstanceUtils.java:51) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.source.TopicSchema.newSchemaInstance(TopicSchema.java:247) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.source.TopicSchema.newSchemaInstance(TopicSchema.java:261) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.source.TopicSchema.lambda$getSchema$2(TopicSchema.java:81) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at java.util.HashMap.computeIfAbsent(HashMap.java:1220) ~[?:?]
	at org.apache.pulsar.functions.source.TopicSchema.getSchema(TopicSchema.java:81) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.source.PulsarSource.buildPulsarSourceConsumerConfig(PulsarSource.java:178) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.source.SingleConsumerPulsarSource.open(SingleConsumerPulsarSource.java:67) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupInput(JavaInstanceRunnable.java:856) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setup(JavaInstanceRunnable.java:253) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:290) ~[org.apache.pulsar-pulsar-functions-instance-3.0.1.jar:3.0.1]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.ClassNotFoundException: org.apache.pulsar.client.impl.schema.ByteBufferSchema
	at java.net.URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:587) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
	at java.lang.Class.forName0(Native Method) ~[?:?]
	at java.lang.Class.forName(Class.java:467) ~[?:?]
	at org.apache.pulsar.common.util.Reflections.createInstance(Reflections.java:70) ~[org.apache.pulsar-pulsar-common-3.0.1.jar:3.0.1]
	... 13 more
```

### Modifications

- Remove custom schema, It is not necessary.
- Upgrade `testcontainers ` version.
- Close container resources when test ends.

### Verifying this change

- Test passed.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

