### PR TITLE
Remove wrong copy command

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -24,4 +24,3 @@ FROM streamnative/pulsar:${PULSAR_IMAGE_TAG}
 COPY ./src/test/resources/pulsar-io-amqp1_0.nar /pulsar/connectors/pulsar-io-amqp1_0.nar
 COPY ./src/test/resources/amqp1_0-source-config.yaml /pulsar/amqp1_0-source-config.yaml
 COPY ./src/test/resources/amqp1_0-sink-config.yaml /pulsar/amqp1_0-sink-config.yaml
-COPY ./src/test/resources/amqp1_0-source-config-session-mode.yaml /pulsar/amqp1_0-source-config-session-mode.yaml


### PR DESCRIPTION
### Modifications

Remove the wrong copy command.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

