### PR TITLE
Fix integration test due to invalid package storage path

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -20,8 +20,11 @@
 ARG PULSAR_IMAGE_TAG
 FROM streamnative/pulsar:${PULSAR_IMAGE_TAG}
 
+USER root
+
 ### Add connector
 COPY ./src/test/resources/pulsar-io-amqp1_0.nar /pulsar/connectors/pulsar-io-amqp1_0.nar
 COPY ./src/test/resources/amqp1_0-source-config.yaml /pulsar/amqp1_0-source-config.yaml
 COPY ./src/test/resources/amqp1_0-sink-config.yaml /pulsar/amqp1_0-sink-config.yaml
 COPY ./src/test/resources/amqp1_0-source-config-session-mode.yaml /pulsar/amqp1_0-source-config-session-mode.yaml
+RUN mkdir -p /pulsar/packages-storage


### PR DESCRIPTION
### Motivation

Error logs
```
2024-04-25T03:10:09,336+0000 [main] ERROR org.apache.pulsar.broker.PulsarService - Failed to start Pulsar service: Failed to create base storage directory at packages-storage
java.lang.RuntimeException: Failed to create base storage directory at packages-storage
	at org.apache.pulsar.packages.management.storage.filesystem.FileSystemPackagesStorage.initialize(FileSystemPackagesStorage.java:75) ~[io.streamnative-pulsar-package-filesystem-storage-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.startPackagesManagementService(PulsarService.java:1799) ~[io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:933) [io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:352) [io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:149) [io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
2024-04-25T03:10:09,336+0000 [main] ERROR org.apache.pulsar.PulsarStandaloneStarter - Failed to start pulsar service.
org.apache.pulsar.broker.PulsarServerException: java.lang.RuntimeException: Failed to create base storage directory at packages-storage
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:966) ~[io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:352) ~[io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:149) [io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
Caused by: java.lang.RuntimeException: Failed to create base storage directory at packages-storage
	at org.apache.pulsar.packages.management.storage.filesystem.FileSystemPackagesStorage.initialize(FileSystemPackagesStorage.java:75) ~[io.streamnative-pulsar-package-filesystem-storage-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.startPackagesManagementService(PulsarService.java:1799) ~[io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:933) ~[io.streamnative-pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	... 2 more
```

### Modifications

Add package store path in the image.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

