### PR TITLE
Support multi-arch connector image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Login streamnative docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set project version
         run: |
           project_version=${GITHUB_REF#refs/tags/v}
@@ -42,5 +48,10 @@ jobs:
           REPO=`mvn -q -Dexec.executable=echo -Dexec.args='${project.artifactId}' --non-recursive exec:exec 2>/dev/null`
           cd -
           IMAGE_REPO=streamnative/${REPO}
-          docker build --build-arg PULSAR_VERSION="$PULSAR_VERSION" -t ${IMAGE_REPO}:${PULSAR_VERSION} -f ./image/Dockerfile ./
-          docker push ${IMAGE_REPO}:${PULSAR_VERSION}
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg PULSAR_VERSION="$PULSAR_VERSION" \
+            -t ${IMAGE_REPO}:${PULSAR_VERSION} \
+            -f ./image/Dockerfile \
+            --push \
+            ./

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
     <testRetryCount>2</testRetryCount>
 
     <!-- connector dependencies -->
-    <jackson.version>2.12.6.1</jackson.version>
-    <lombok.version>1.18.22</lombok.version>
-    <pulsar.version>4.0.1.4</pulsar.version>
+    <jackson.version>2.18.6</jackson.version>
+    <lombok.version>1.18.42</lombok.version>
+    <pulsar.version>4.2.0.6</pulsar.version>
     <qpid.version>1.8.0</qpid.version>
     <log4j2.version>2.17.1</log4j2.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
 
     <!-- test dependencies -->
     <junit.version>4.13.1</junit.version>
@@ -101,6 +101,21 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes https://github.com/streamnative/product-roadmap/issues/1572

## Summary
- Upgrade the connector runtime to Pulsar `4.2.0.6` and align shared dependency versions with Pulsar `branch-4.2` where applicable.
- Update release image workflows to use Buildx/QEMU and publish `linux/amd64,linux/arm64` images.
- Keep existing test boundaries unchanged; this PR does not add Surefire test excludes or change unit-test workflow commands.

## Validation
- `mvn clean install -DskipTests`
- workflow YAML parse check
- `git diff --check`

Note: after keeping the original test boundaries, `mvn test -Dtest="*Test" -DfailIfNoTests=false` may reach existing external integration tests in some connectors and requires their normal external services, such as Docker/Testcontainers or LocalStack.